### PR TITLE
Allow out-of-tree caching

### DIFF
--- a/config.php
+++ b/config.php
@@ -58,8 +58,9 @@ $settings["imagePrefix"] = "/img";
 /**
  * Directory to store thumbnails and other resized images
  *
- * Created in every gallery folder
- * Therefore the gallery folder must be writable to the webserver
+ * Name of a folder which will be created in every gallery folder
+ * (which means the gallery folder must be writable to the webserver)
+ * or an absolute path to another folder which will be used.
  * Comment out to disable caching.
  */
 $settings["cacheFolder"] = ".cache";

--- a/lib/img/ImageHandler.php
+++ b/lib/img/ImageHandler.php
@@ -50,12 +50,25 @@ class ImageHandler {
 		$cachedImgName = $size.'_'.basename($this->file->getPath());
 
 		if (!empty($this->settings->cacheFolder)) {
-			$cache = new ImageCache($this->file->getFolder()->getPath(), $this->settings->cacheFolder);
+			if ($this->settings->cacheFolder[0] === '/') {
+				$cachePath = $this->settings->cacheFolder .
+					preg_replace(
+						'/^'.preg_quote($this->settings->dataDirectory, '/').'/',
+						'',
+						$this->file->getFolder()->getPath()
+						);
+				$cacheFolder = '.cache';
+				if (!is_dir($cachePath)) mkdir($cachePath, 0777, true);
+			} else {
+				$cachePath = $this->file->getFolder()->getPath();
+				$cacheFolder = $this->settings->cacheFolder;
+			}
+			$cache = new ImageCache($cachePath, $cacheFolder);
 			if (!$cache->exists()) return;
 
 			if ($cache->inCache($cachedImgName)) {
 				$imagestat = stat($this->file->getPath());
-				$cachestat = stat(dirname($this->file->getPath()).'/'.$this->settings->cacheFolder.'/'.$cachedImgName);
+				$cachestat = stat($cache->getPath().'/'.$cachedImgName);
 
 				if ($imagestat['mtime'] < $cachestat['mtime']) {
 					$cache->read($cachedImgName);


### PR DESCRIPTION
This allow caching in a folder outside of the data directory. This is especially helpful when the data directory is read-only.