### PR TITLE
Implement imageSize parameter

### DIFF
--- a/config.php
+++ b/config.php
@@ -84,6 +84,7 @@ $settings["thumbnailSize"] = 100;
  * Full image size
  *
  * Image size for full image preview
+ * Uncomment to always return the original image.
  */
 $settings["imageSize"] = 600;
 

--- a/lib/controllers/Image.php
+++ b/lib/controllers/Image.php
@@ -81,8 +81,23 @@ class Image extends Controller {
 			$this->fileSystem->getFile()->read();
 			return $response;
 		}
+		$exif = exif_read_data($this->fileSystem->getFile()->getPath());
+		$orientation = 0;
+		if ($exif !== FALSE && !empty($exif['Orientation'])) {
+			switch ($exif['Orientation']) {
+			case 3:
+				$orientation = 180;
+				break;
+			case 6:
+				$orientation = -90;
+				break;
+			case 8:
+				$orientation = 90;
+				break;
+			}
+		}
 		$imageHandler = new ImageHandler($request->getAcceptedType(), $this->settings, $this->fileSystem->getFile());
-		$imageHandler->resizeImage($resizeTo, 0);
+		$imageHandler->resizeImage($resizeTo, $orientation);
 		return $response;
 	}
 }

--- a/lib/controllers/Image.php
+++ b/lib/controllers/Image.php
@@ -63,11 +63,12 @@ class Image extends Controller {
 		switch ($request->getRequestType()) {
 			case RequestType::IMAGE_FILE:
 				$response->asType(ResponseCode::OK, $request->getAcceptedType());
-				$this->fileSystem->getFile()->read();
-				return $response;
+				$resizeTo = $this->settings->imageSize;
+				break;
 
 			case RequestType::THUMBNAIL_FILE:
 				$response->asType(ResponseCode::OK, $request->getAcceptedType());
+				$resizeTo = $this->settings->thumbnailSize;
 				break;
 
 			default:
@@ -76,8 +77,12 @@ class Image extends Controller {
 		}
 
 		// Thumbnail was requested
+		if ($resizeTo == 0) {
+			$this->fileSystem->getFile()->read();
+			return $response;
+		}
 		$imageHandler = new ImageHandler($request->getAcceptedType(), $this->settings, $this->fileSystem->getFile());
-		$imageHandler->resizeImage($this->settings->thumbnailSize, 0);
+		$imageHandler->resizeImage($resizeTo, 0);
 		return $response;
 	}
 }

--- a/lib/system/Settings.php
+++ b/lib/system/Settings.php
@@ -27,7 +27,7 @@ class Settings {
 
 	public $thumbnailSize = 100;
 
-	public $imageSize = 600;
+	public $imageSize = 0;
 
 	public $badgeWidth = 200;
 


### PR DESCRIPTION
The `imageSize` setting from `config.php` was unused. This PR adds the functionality.
When not specified, the old behaviour is kept.

I've also added image rotation based on EXIF tags. If you want me to split the PR, please let me know.